### PR TITLE
Fix module name in "Shared Commanders and Living Assigns"

### DIFF
--- a/web/templates/live/index.html.drab
+++ b/web/templates/live/index.html.drab
@@ -645,7 +645,7 @@ end/%></code></pre>
 
     <p>
       What to do if we want to update the corresponding section of the page with <code>poke</code>? The answer is: <b>nothing</b>. All is done automagically. Only the assigns, which are in the same <code>drab-commander</code> section as the element, which generated the event, are updated.
-      <pre><code class="elixir"><%=~S/defmodule DrabPoc.Timer2Commander do
+      <pre><code class="elixir"><%=~S/defmodule DrabPoc.Timer3Commander do
   use Drab.Commander
 
   defhandler countdown(socket, _sender, options) do


### PR DESCRIPTION
The name of the drab-commender in the template is `ZDrabPoc.Timer3Commander` but the Elixir  module is called `DrabPoc.Timer2Commander`. This just changes the Elixir module to have the correct name.